### PR TITLE
Use isort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+# pyShelf uses its own `lib` directory, don't ignore it.
+# lib/
 lib64/
 parts/
 sdist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,15 @@ repos:
     rev: v1.3.0
     hooks:
       - id: trailing-whitespace
+
+  # Python import formatting
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.3
+    hooks:
+      - id: seed-isort-config
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21-2
+    hooks:
+      - id: isort
+        additional_dependencies: ["toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  # Meta housekeeping to keep pre-commit operating correctly
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
+  # General housekeeping and auto-fixers
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.3.0
+    hooks:
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -4,15 +4,22 @@ A simple terminal based ebook server
 Frustrated with Calibre being my only option for hosting my eBook collection, I have decided to spin up my own.
 
 Calibre is a great organizational tool for your books, however not having a terminal based option for running and maintaining
-a server is cumbersome when running on a headless server. 
+a server is cumbersome when running on a headless server.
 Calibre does have a console based server solution, However there is currently no way to create, and manage your library in a headless enviroment.
 
 Thus I am creating pyShelf and I hope to be able to provide all the functionality required to organize and host all your ebooks.
 
 I am open to and hoping for community help in the design and execution of this program.
+
+## Development
+pyShelf uses [`pre-commit`](https://pre-commit.com/) to automate some tasks.
+Before developing, run `pre-commit install`.
+See the [documentation](https://pre-commit.com/) for more information.
+
 ## Configuration
 All configuration is done in config.py.
 The only currently required configuration is to set book_path to the location of your books.
+
 ## Current Features
 Currently pyShelf will recursively scan your collection, extract and store some metadata in the sqlite database.
 The basic template system is in place, as well as a template mockup. This can be seen hosted on port 8000
@@ -21,7 +28,7 @@ The basic template system is in place, as well as a template mockup. This can be
 * HTML Frontend for file transfers
 * HTML Backend for catalogue maintenance
 * Terminal Backend for catalogue maintenance
-* Calculate page count from total characters 
+* Calculate page count from total characters
   * (Thanks to @Fireblend for the idea) https://github.com/th3r00t/pyShelf/issues/3
 * Move towards sqlAlchemy and enable user to specify desired storage system
   * (Thanks to Sarcism) over on r/opensource for this idea!

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
-import sys
 import os
+import sys
+
 sys.path.insert(0, os.path.abspath('.'))

--- a/lib/api_hooks.py
+++ b/lib/api_hooks.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 import sys
+
 import requests
+
 # sys.path.insert(1, 'lib/')
 
 

--- a/lib/display.py
+++ b/lib/display.py
@@ -2,8 +2,9 @@
 import cgi
 import sys
 
-sys.path.insert(0, '../')
 from config import Config
+
+sys.path.insert(0, '../')
 
 
 class Frontend():

--- a/lib/pyShelf.py
+++ b/lib/pyShelf.py
@@ -111,7 +111,7 @@ class BookDisplay:
 
 class BookServer:
     """
-    HTTP server functions required to display e-books    
+    HTTP server functions required to display e-books
     """
 
     def __init__(self):

--- a/lib/storage.py
+++ b/lib/storage.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python
-import sys
 import sqlite3
+import sys
+
 # sys.path.insert(1, '../')
 from config import Config
+
 db_pointer = Config().catalogue_db
 
 

--- a/main.py
+++ b/main.py
@@ -2,11 +2,10 @@
 import sys
 
 from config import Config
-from lib.library import Catalogue
-from lib.pyShelf import InitFiles
-from lib.pyShelf import BookServer
-from lib.pyShelf import BookDisplay
 from lib.display import Frontend
+from lib.library import Catalogue
+from lib.pyShelf import BookDisplay, BookServer, InitFiles
+
 # sys.path.insert(1, 'lib/')
 
 config = Config()  # Get configuration settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.isort]
+force_grid_wrap = 0
+include_trailing_comma = true
+line_length = 88
+multi_line_output = 3
+use_parentheses = true
+# NOTE: the known_third_party setting is managed by
+# seed-isort-config and should not be modified directly.
+# Any changes made to this setting will be overwritten.
+known_third_party = ["PIL", "bs4", "requests"]

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -25,7 +25,7 @@ body{
     font-size: 25px;
     text-align: start;
 }
-.shadow{ 
+.shadow{
     text-shadow: #4c5c68 -5px 3px 5px;
 }
 .app_subhdr{
@@ -61,7 +61,7 @@ body{
     grid-area: right_col
 }
 .python_logo{
-    
+
 }
 #python_logo{
     height: 50px;

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 import sys
+
 sys.path.insert(1, '../lib/')

--- a/tests/test_bookserver.py
+++ b/tests/test_bookserver.py
@@ -1,8 +1,9 @@
 import sys
 import unittest
 
-from lib.pyShelf import BookDisplay, BookServer
 from lib.display import Frontend
+from lib.pyShelf import BookDisplay, BookServer
+
 sys.path.insert(0, '../lib')
 sys.path.insert(1, '../')
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,6 @@
-import unittest
 import sys
+import unittest
+
 # sys.path.insert(1, '../')
 from lib.storage import Storage
 


### PR DESCRIPTION
[isort](https://isort.readthedocs.io/en/latest/) sorts your Python
imports so you don't have to. This makes sure that imports are always
where they should be and prevents issues like duplicated imports and
merge conflicts. Using pre-commit, this can be done automatically
without any manual steps.

Depends on #9.